### PR TITLE
New decompile-free faster build process

### DIFF
--- a/IronChests2/pom.xml
+++ b/IronChests2/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>mods.cpw</groupId>
+  <artifactId>ironchest</artifactId>
+  <version>5.2.0</version>
+  <name>ironchest</name>
+  <url>https://github.com/cpw/ironchest</url>
+
+  <parent>
+    <groupId>net.md-5</groupId>
+    <artifactId>ForgeMod</artifactId>
+    <version>1.5-7.7.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>sonatype-oss-public</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <sourceDirectory>${basedir}/common</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>${basedir}/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+</project>

--- a/IronChests2/resources/mcmod.info
+++ b/IronChests2/resources/mcmod.info
@@ -3,8 +3,8 @@
   "modid": "IronChest",
   "name": "Iron Chest",
   "description": "New chests with larger sizes, with in-place upgrade items.\nThe feature chest is the crystal chest, which is transparent - some inventory contents are visible without opening the chest",
-  "version": "@VERSION@",
-  "mcversion": "1.4.4",
+  "version": "${project.version}",
+  "mcversion": "${minecraft.version}",
   "url": "http://www.minecraftforum.net/topic/981855-",
   "updateUrl": "",
   "authors": [


### PR DESCRIPTION
Adds a Maven pom.xml for building IronChest using the new process as we were briefly discussing on IRC yesterday. Since you wanted to see it, here it is :). 

To build, install Maven 3 then run:

```
mvn initialize -P -built
mvn package
```

The mod will be compiled against the remapped library then reobfuscated to "srg" names for FML runtime deobfuscation, the final product in target. Tested on Minecraft 1.5 with Forge 7.7.0.566.

On my system, builds in less than 3 seconds:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.852s
[INFO] Finished at: Sun Mar 10 18:57:21 PDT 2013
[INFO] Final Memory: 20M/215M
[INFO] ------------------------------------------------------------------------
```
