### PR TITLE
Spelling error fixes to da_DK.lang

### DIFF
--- a/IronChests2/resources/assets/ironchest/lang/da_DK.lang
+++ b/IronChests2/resources/assets/ironchest/lang/da_DK.lang
@@ -1,17 +1,17 @@
 tile.ironchest:IRON.name=Jern Kiste
 tile.ironchest:GOLD.name=Guld Kiste
-tile.ironchest:DIAMOND.name=Diamand Kiste
+tile.ironchest:DIAMOND.name=Diamant Kiste
 tile.ironchest:COPPER.name=Kobber Kiste
 tile.ironchest:SILVER.name=Sølv Kiste
 tile.ironchest:CRYSTAL.name=Krystal Kiste
 tile.ironchest:OBSIDIAN.name=Obsidian Kiste
 
-item.ironchest:IRONGOLD.name=Jern til Guld Kiste Upgradering
-item.ironchest:GOLDDIAMOND.name=Guld til Diamand Kiste Upgradering
-item.ironchest:COPPERSILVER.name=Kobber til Sølv Kiste Upgradering
-item.ironchest:SILVERGOLD.name=Sølv til Guld Kiste Upgradering
-item.ironchest:COPPERIRON.name=Kobber til Jern Kiste Upgradering
-item.ironchest:DIAMONDCRYSTAL.name=Diamand til Krystal Kiste Upgradering
-item.ironchest:WOODIRON.name=Træ til Jern Kiste Upgradering
-item.ironchest:WOODCOPPER.name=Træ til Kobber Kiste Upgradering
-item.ironchest:DIAMONDOBSIDIAN.name=Diamand til Obsidian Kiste Upgradering
+item.ironchest:IRONGOLD.name=Jern til Guld Kiste Opgradering
+item.ironchest:GOLDDIAMOND.name=Guld til Diamant Kiste Opgradering
+item.ironchest:COPPERSILVER.name=Kobber til Sølv Kiste Opgradering
+item.ironchest:SILVERGOLD.name=Sølv til Guld Kiste Opgradering
+item.ironchest:COPPERIRON.name=Kobber til Jern Kiste Opgradering
+item.ironchest:DIAMONDCRYSTAL.name=Diamant til Krystal Kiste Opgradering
+item.ironchest:WOODIRON.name=Træ til Jern Kiste Opgradering
+item.ironchest:WOODCOPPER.name=Træ til Kobber Kiste Opgradering
+item.ironchest:DIAMONDOBSIDIAN.name=Diamant til Obsidian Kiste Opgradering


### PR DESCRIPTION
"Daimand" is not actually a word in Danish, it should be "Diamant".
Similarly, "Upgradering" should have been "Opgradering".
